### PR TITLE
Removed dependency for PPPoED_Tags

### DIFF
--- a/PPPoE_Simulator.py
+++ b/PPPoE_Simulator.py
@@ -60,9 +60,7 @@ def packet_callback(pkt):
         if pkt[PPPoED].code == PADI:
             session_id = pkt[PPPoED].fields['sessionid']
             ac_cookie = os.urandom(20)
-            for tag in pkt[PPPoED][PPPoED_Tags].tag_list:
-                if tag.tag_type == Host_Uniq:
-                    host_uniq = tag.tag_value
+            host_uniq = ""
             print("Client->Server   |   Discovery Initiation")
             print("Server->Client   |   Discovery Offer")
             sendp(eth_discovery /


### PR DESCRIPTION
Only certain versions of Scappy support the PPPoED_Tags and the authentication seems to work without setting the host_uniq tag.